### PR TITLE
テーブルを修正

### DIFF
--- a/db/migrate/20190124155236_user.rb
+++ b/db/migrate/20190124155236_user.rb
@@ -1,4 +1,0 @@
-class User < ActiveRecord::Migration[5.2]
-  def change
-  end
-end

--- a/db/migrate/20190419034247_add_column_to_user.rb
+++ b/db/migrate/20190419034247_add_column_to_user.rb
@@ -1,0 +1,5 @@
+class AddColumnToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :user_type, :integer
+  end
+end

--- a/db/migrate/20190419034547_remove_column_from_users.rb
+++ b/db/migrate/20190419034547_remove_column_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveColumnFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :available_place, :string
+  end
+end

--- a/db/migrate/20190419034848_change_column_to_shifts.rb
+++ b/db/migrate/20190419034848_change_column_to_shifts.rb
@@ -1,0 +1,6 @@
+class ChangeColumnToShifts < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :shifts, :start_time, :scheduled_from
+    rename_column :shifts, :end_time, :scheduled_to
+  end
+end

--- a/db/migrate/20190419035301_rename_works_to_funerals.rb
+++ b/db/migrate/20190419035301_rename_works_to_funerals.rb
@@ -1,0 +1,5 @@
+class RenameWorksToFunerals < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :works, :funerals
+  end
+end

--- a/db/migrate/20190419035412_remove_column_from_funerals.rb
+++ b/db/migrate/20190419035412_remove_column_from_funerals.rb
@@ -1,0 +1,5 @@
+class RemoveColumnFromFunerals < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :funerals, :end_time, :datetime
+  end
+end

--- a/db/migrate/20190419040125_rename_machings_to_matchings.rb
+++ b/db/migrate/20190419040125_rename_machings_to_matchings.rb
@@ -1,0 +1,5 @@
+class RenameMachingsToMatchings < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :machings, :matchings
+  end
+end

--- a/db/migrate/20190419040243_remove_column_from_clients.rb
+++ b/db/migrate/20190419040243_remove_column_from_clients.rb
@@ -1,0 +1,5 @@
+class RemoveColumnFromClients < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :clients, :work_id, :integer
+  end
+end

--- a/db/migrate/20190419040418_rename_places_to_funeral_halls.rb
+++ b/db/migrate/20190419040418_rename_places_to_funeral_halls.rb
@@ -1,0 +1,5 @@
+class RenamePlacesToFuneralHalls < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :places, :funeral_halls
+  end
+end

--- a/db/migrate/20190419040504_remove_column_from_funeral_halls.rb
+++ b/db/migrate/20190419040504_remove_column_from_funeral_halls.rb
@@ -1,0 +1,5 @@
+class RemoveColumnFromFuneralHalls < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :funeral_halls, :work_id, :integer
+  end
+end

--- a/db/migrate/20190419040714_drop_trasportation_fees.rb
+++ b/db/migrate/20190419040714_drop_trasportation_fees.rb
@@ -1,0 +1,5 @@
+class DropTrasportationFees < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :transportation_fees
+  end
+end

--- a/db/migrate/20190419042906_create_available_halls.rb
+++ b/db/migrate/20190419042906_create_available_halls.rb
@@ -1,0 +1,8 @@
+class CreateAvailableHalls < ActiveRecord::Migration[5.2]
+  def change
+    create_table :available_halls do |t|
+      t.integer :user_id
+      t.integer :funeral_hall_id
+    end
+  end
+end

--- a/db/migrate/20190419045315_add_column_to_clients.rb
+++ b/db/migrate/20190419045315_add_column_to_clients.rb
@@ -1,0 +1,5 @@
+class AddColumnToClients < ActiveRecord::Migration[5.2]
+  def change
+    add_column :clients, :funeral_id, :integer
+  end
+end

--- a/db/migrate/20190419045339_add_column_to_funeral_halls.rb
+++ b/db/migrate/20190419045339_add_column_to_funeral_halls.rb
@@ -1,0 +1,5 @@
+class AddColumnToFuneralHalls < ActiveRecord::Migration[5.2]
+  def change
+    add_column :funeral_halls, :funeral_id, :integer
+  end
+end

--- a/db/migrate/20190419054432_remove_column_from_available_halls.rb
+++ b/db/migrate/20190419054432_remove_column_from_available_halls.rb
@@ -1,0 +1,5 @@
+class RemoveColumnFromAvailableHalls < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :available_halls, :user_id, :integer
+  end
+end

--- a/db/migrate/20190419054434_rename_column_to_available_halls.rb
+++ b/db/migrate/20190419054434_rename_column_to_available_halls.rb
@@ -1,0 +1,5 @@
+class RenameColumnToAvailableHalls < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :available_halls, :user_id_id, :user_id
+  end
+end

--- a/db/migrate/20190419054540_remove_funeral_id_from_clients.rb
+++ b/db/migrate/20190419054540_remove_funeral_id_from_clients.rb
@@ -1,0 +1,5 @@
+class RemoveFuneralIdFromClients < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :clients, :funeral_id, :integer
+  end
+end

--- a/db/migrate/20190419054541_add_funeral_id_to_clients.rb
+++ b/db/migrate/20190419054541_add_funeral_id_to_clients.rb
@@ -1,0 +1,5 @@
+class AddFuneralIdToClients < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :clients, :funeral, foreign_key: true
+  end
+end

--- a/db/migrate/20190419055206_remove_funeral_id_from_funeral_halls.rb
+++ b/db/migrate/20190419055206_remove_funeral_id_from_funeral_halls.rb
@@ -1,0 +1,5 @@
+class RemoveFuneralIdFromFuneralHalls < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :funeral_halls, :funeral_id, :integer
+  end
+end

--- a/db/migrate/20190419055207_add_funeral_id_to_funeral_halls.rb
+++ b/db/migrate/20190419055207_add_funeral_id_to_funeral_halls.rb
@@ -1,0 +1,5 @@
+class AddFuneralIdToFuneralHalls < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :funeral_halls, :funeral, foreign_key: true
+  end
+end

--- a/db/migrate/20190419055438_remove_column_from_matchings.rb
+++ b/db/migrate/20190419055438_remove_column_from_matchings.rb
@@ -1,0 +1,6 @@
+class RemoveColumnFromMatchings < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :matchings, :shift_id, :integer
+    remove_column :matchings, :work_id, :integer
+  end
+end

--- a/db/migrate/20190419055439_add_references_to_matchings.rb
+++ b/db/migrate/20190419055439_add_references_to_matchings.rb
@@ -1,0 +1,6 @@
+class AddReferencesToMatchings < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :available_halls, :user, foreign_key: true
+    add_reference :available_halls, :funeral, foreign_key: true
+  end
+end

--- a/db/migrate/20190419055704_remove_user_id_from_shifts.rb
+++ b/db/migrate/20190419055704_remove_user_id_from_shifts.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromShifts < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :shifts, :user_id, :integer
+  end
+end

--- a/db/migrate/20190419055705_add_user_id_to_shifts.rb
+++ b/db/migrate/20190419055705_add_user_id_to_shifts.rb
@@ -1,0 +1,5 @@
+class AddUserIdToShifts < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :shifts, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20190419055726_remove_user_id_from_working_hours.rb
+++ b/db/migrate/20190419055726_remove_user_id_from_working_hours.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromWorkingHours < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :working_hours, :user_id, :integer
+  end
+end

--- a/db/migrate/20190419055727_add_user_id_to_working_hours.rb
+++ b/db/migrate/20190419055727_add_user_id_to_working_hours.rb
@@ -1,0 +1,5 @@
+class AddUserIdToWorkingHours < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :working_hours, :user, foreign_key: true
+  end
+end


### PR DESCRIPTION
# 概要
機能の変更や、頂いたアドバイスに沿って、テーブル構成を見直し、修正します。

テーブル名・カラム名の変更・削除が主です。

変更後のリレーションマップ（テーブル構成に変化はありません）
![image](https://user-images.githubusercontent.com/43634511/56405775-c32c5100-62a8-11e9-865d-6a066a42d155.png)

 # 詳細
 ### user
- user_typeカラムの追加
- available_placeカラムの削除

 ### shift 
- start_time -> scheduled_formにカラム名変更
- end_time -> scheduled_toにカラム名変更

 ### works
- テーブル名をfuneralsに改名
- end_timeを削除

 ### maching
- テーブル名をmatchingにスペルを直す

 ### client 
- work_idをfuneral_idに変更

 ### places
- テーブルをfuneral_hallsに改名
- work_idをfuneral_idに変更

 ### transportation_fees
- 削除（不要なので）

 ### available_halls
- テーブル新規作成、usersとfuneral_halls間のブリッジテーブル

よろしくお願いします！