### PR TITLE
カラム名のスペルミス修正

### DIFF
--- a/db/migrate/20190124151225_create_users.rb
+++ b/db/migrate/20190124151225_create_users.rb
@@ -2,7 +2,7 @@ class CreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :users do |t|
       t.string :name
-      t.string :mail
+      t.string :email
       t.string :address
       t.string :nearest_station
       t.integer :user_type

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,7 +69,7 @@ ActiveRecord::Schema.define(version: 2019_02_04_060946) do
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
-    t.string "mail"
+    t.string "email"
     t.string "address"
     t.string "nearest_station"
     t.integer "user_type"


### PR DESCRIPTION
# 概要
Userテーブルの`mail`カラムを `email`カラムに修正します。