### PR TITLE
routes.rbが抜けていたので適用

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,13 @@
 Rails.application.routes.draw do
 
   root 'staff/sessions#new'
+  post   '/login'   => 'sessions#create'
+  delete '/logout'  => 'sessions#destroy'
 
   namespace :staff do
 
     get '/signup',  to: 'users#new'
     post '/signup'  => 'users#create'
-
-
-    post   '/login'   => 'sessions#create'
-
-    delete '/logout'  => 'sessions#destroy'
 
     get    '/home',   to: 'static_pages#home'
 
@@ -18,7 +15,7 @@ Rails.application.routes.draw do
 
     resources :users
 
-    resources :funeral_hallss, :except => [:show]
+    resources :funeral_halls, :except => [:show]
 
     resources :clients, :except => [:show]
 
@@ -38,14 +35,14 @@ Rails.application.routes.draw do
 
     resources :users
 
-    resources :funeral_hallss, :except => [:show]
+    resources :funeral_halls, :except => [:show]
 
     resources :clients, :except => [:show]
 
     resources :funerals
 
-    get   '/search_page',  to: 'funerals#search_page'
-    get   '/search',  to: 'funerals#search'
+    get   '/search_page',  to: 'works#search_page'
+    get   '/search',  to: 'works#search'
 
     resources :machings
 


### PR DESCRIPTION
## 概要

880223237f55a472448c646d701729b274f22b06
で、修正したモデル名をapp全体に適用させましたが、
routes.rbが抜けていたので、追加で修正します。