### PR TITLE
スペルミスを修正

### DIFF
--- a/app/controllers/admin/funeral_halls_controller.rb
+++ b/app/controllers/admin/funeral_halls_controller.rb
@@ -2,7 +2,7 @@ class Admin::FuneralHallsController < Admin::ApplicationController
 before_action :logged_in_user, only: [:show, :edit, :update, :destroy]
 
     def index
-      @funeral_hallss = FuneralHall.all
+      @funeral_halls = FuneralHall.all
     end
 
     def new
@@ -25,7 +25,7 @@ before_action :logged_in_user, only: [:show, :edit, :update, :destroy]
     def update
       funeral_halls = FuneralHall.find(params[:id])
       if funeral_halls.update(funeral_halls_params)
-        redirect_to admin_funeral_hallss_path
+        redirect_to admin_funeral_halls_path
       else
         render :edit
       end

--- a/app/controllers/admin/machings_controller.rb
+++ b/app/controllers/admin/machings_controller.rb
@@ -8,7 +8,7 @@ class Admin::MachingsController < Admin::ApplicationController
     end
 
     @funerals.each do |funeral|
-      @funeral_hallss = FuneralHall.where(id: funeral.funeral_halls_id)
+      @funeral_halls = FuneralHall.where(id: funeral.funeral_halls_id)
       @clients = Client.where(id: funeral.client_id)
     end
 

--- a/app/controllers/staff/funeral_halls_controller.rb
+++ b/app/controllers/staff/funeral_halls_controller.rb
@@ -2,7 +2,7 @@ class Staff::FuneralHallsController < Staff::ApplicationController
 before_action :logged_in_user, only: [:show, :edit, :update, :destroy]
 
     def index
-      @funeral_hallss = FuneralHall.all
+      @funeral_halls = FuneralHall.all
     end
 
     def new
@@ -25,7 +25,7 @@ before_action :logged_in_user, only: [:show, :edit, :update, :destroy]
     def update
       funeral_halls = FuneralHall.find(params[:id])
       if funeral_halls.update(funeral_halls_params)
-        redirect_to staff_funeral_hallss_path
+        redirect_to staff_funeral_halls_path
       else
         render :edit
       end

--- a/app/views/admin/_nav_content.html.erb
+++ b/app/views/admin/_nav_content.html.erb
@@ -3,7 +3,7 @@
   <ul>
     <li><%= link_to "仕事を入力する", admin_search_page_path %></li>
     <li><%= link_to "仕事一覧", admin_funerals_path %></li>
-    <li><%= link_to "会場一覧", admin_funeral_hallss_path %></li>
+    <li><%= link_to "会場一覧", admin_funeral_halls_path %></li>
     <li><%= link_to "取引先一覧", admin_clients_path %></li>
     <li><%= link_to "スタッフ一覧", admin_users_path %></li>
   </ul>

--- a/app/views/admin/funeral_halls/edit.html.erb
+++ b/app/views/admin/funeral_halls/edit.html.erb
@@ -2,4 +2,4 @@
 
 <%= render :partial => "form" %>
 
-<%= link_to "一覧に戻る", admin_funeral_hallss_path %>
+<%= link_to "一覧に戻る", admin_funeral_halls_path %>

--- a/app/views/admin/funeral_halls/index.html.erb
+++ b/app/views/admin/funeral_halls/index.html.erb
@@ -1,6 +1,6 @@
 <h1>会場一覧</h1>
 <ul>
-  <% @funeral_hallss.each do |funeral_halls| %>
+  <% @funeral_halls.each do |funeral_halls| %>
   <li>会館名：<%= funeral_halls.name %></li>
   <li>住所：<%= funeral_halls.address %></li>
   <li>最寄駅：<%= funeral_halls.nearest_station %></li>

--- a/app/views/admin/funeral_halls/new.html.erb
+++ b/app/views/admin/funeral_halls/new.html.erb
@@ -2,5 +2,5 @@
 
 <%= render :partial => "form" %>
 
-<li><%= link_to '一覧に戻る', admin_funeral_hallss_path %></li>
+<li><%= link_to '一覧に戻る', admin_funeral_halls_path %></li>
 </ul>

--- a/app/views/admin/machings/index.html.erb
+++ b/app/views/admin/machings/index.html.erb
@@ -14,7 +14,7 @@
 </li>
 
 <li>会場：
-  <% @funeral_hallss.each do |funeral_halls| %>
+  <% @funeral_halls.each do |funeral_halls| %>
     <%= funeral_halls.name %>
   <% end %>
 </li>

--- a/app/views/staff/_nav_content.html.erb
+++ b/app/views/staff/_nav_content.html.erb
@@ -3,7 +3,7 @@
   <ul>
     <li><%= link_to "シフトを入力する", :controller => "staff/shifts", :action => "new" %></li>
     <li><%= link_to "シフト一覧をみる", :controller => "staff/shifts", :action => "index" %></li>
-    <li><%= link_to "会場一覧", staff_funeral_hallss_path %></li>
+    <li><%= link_to "会場一覧", staff_funeral_halls_path %></li>
     <li><%= link_to "取引先一覧", staff_clients_path %></li>
     <li><%= link_to "給与明細", staff_payslip_path %></li>
     <li><%= link_to "ログアウト", staff_logout_path, method: :delete %></li>

--- a/app/views/staff/funeral_halls/edit.html.erb
+++ b/app/views/staff/funeral_halls/edit.html.erb
@@ -2,4 +2,4 @@
 
 <%= render :partial => "form" %>
 
-<%= link_to "一覧に戻る", staff_funeral_hallss_path %>
+<%= link_to "一覧に戻る", staff_funeral_halls_path %>

--- a/app/views/staff/funeral_halls/index.html.erb
+++ b/app/views/staff/funeral_halls/index.html.erb
@@ -1,6 +1,6 @@
 <h1>会場一覧</h1>
 <ul>
-  <% @funeral_hallss.each do |funeral_halls| %>
+  <% @funeral_halls.each do |funeral_halls| %>
   <li>会館名：<%= funeral_halls.name %></li>
   <li>住所：<%= funeral_halls.address %></li>
   <li>最寄駅：<%= funeral_halls.nearest_station %></li>

--- a/app/views/staff/funeral_halls/new.html.erb
+++ b/app/views/staff/funeral_halls/new.html.erb
@@ -2,5 +2,5 @@
 
 <%= render :partial => "form" %>
 
-<li><%= link_to '一覧に戻る', staff_funeral_hallss_path %></li>
+<li><%= link_to '一覧に戻る', staff_funeral_halls_path %></li>
 </ul>

--- a/app/views/staff/machings/index.html.erb
+++ b/app/views/staff/machings/index.html.erb
@@ -14,7 +14,7 @@
 </li>
 
 <li>会場：
-  <% @funeral_hallss.each do |funeral_halls| %>
+  <% @funeral_halls.each do |funeral_halls| %>
     <%= funeral_halls.name %>
   <% end %>
 </li>


### PR DESCRIPTION
 ## 概要
880223237f55a472448c646d701729b274f22b06
で修正したモデル名のうち、
 `funeral_halls`が `funeral_hallss`になっていたのを修正します。