### PR TITLE
モデル名修正の漏れを修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,8 +41,8 @@ Rails.application.routes.draw do
 
     resources :funerals
 
-    get   '/search_page',  to: 'works#search_page'
-    get   '/search',  to: 'works#search'
+    get   '/search_page',  to: 'funerals#search_page'
+    get   '/search',  to: 'funerals#search'
 
     resources :machings
 


### PR DESCRIPTION
## 概要
routes.rbに、まだ修正前のモデル名が残っていたのを、修正します。