### PR TITLE
スタッフ検索から保存までの実装

### DIFF
--- a/app/controllers/admin/funerals_controller.rb
+++ b/app/controllers/admin/funerals_controller.rb
@@ -17,7 +17,8 @@ class Admin::FuneralsController < Admin::ApplicationController
     end
 
     @funeral = Funeral.new(start_time: start_time, number_of_people: params[:number_of_people])
-    @hall_name = FuneralHall.find(params[:funeral_hall]).name
+    @hall_id = params[:funeral_hall]
+    @hall_name = FuneralHall.find(@hall_id).name
     @clients = Client.all
   end
 
@@ -61,7 +62,13 @@ class Admin::FuneralsController < Admin::ApplicationController
   private
 
     def funeral_params
-    params.require(:funeral).permit(:id, :funeral_halls_id, :client_id, :start_time, :end_time, working_hours_attributes:['0': :shift_id] )
+    params.require(:funeral)
+          .permit(:start_time,
+                  :funeral_hall_id,
+                  :client_id,
+                  :family_name,
+                  :number_of_people,
+                  working_hours_attributes:[:user_id, :status])
     end
 
 end

--- a/app/controllers/admin/funerals_controller.rb
+++ b/app/controllers/admin/funerals_controller.rb
@@ -5,22 +5,24 @@ class Admin::FuneralsController < Admin::ApplicationController
   end
 
   def new
-    start_time = Time.zone.local(params['start_time(1i)'].to_i, params['start_time(2i)'].to_i, params['start_time(3i)'].to_i, params['start_time(4i)'].to_i, params['start_time(5i)'].to_i)
-    end_time = Time.zone.local(params['end_time(1i)'].to_i, params['end_time(2i)'].to_i, params['end_time(3i)'].to_i, params['end_time(4i)'].to_i, params['end_time(5i)'].to_i)
-    @funeral = Funeral.new(start_time: start_time, end_time: end_time)
-    @shift = Shift.new
-    @shifts = @shift.matches(start_time, end_time)
+    start_time = Time.zone.parse(params[:start_date] + " " + params[:start_time])
+    quickest_end_time = start_time + 4.hours
 
+    @shift = Shift.new
+    @shifts = @shift.matches(start_time, quickest_end_time)
     @users = []
     @shifts.each do |shift|
       user = User.find(shift.user_id)
       @users.append(user)
     end
+
+    @funeral = Funeral.new(start_time: start_time, number_of_people: params[:number_of_people])
+    @hall_name = FuneralHall.find(params[:funeral_hall]).name
+    @clients = Client.all
   end
 
   def create
     funeral = Funeral.new(funeral_params)
-    binding.pry
     if funeral.save!
       redirect_to admin_funerals_path
     else

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -6,11 +6,10 @@ with_options presence: true do
   validates :scheduled_to
 end
 
-  def matches(start_time, end_time)
+  def matches(start_time, quickest_end_time)
     results = Shift.all
-    results = results.where("start_time <= ?", start_time)
-    results = results.where("end_time >= ?", end_time)
-
+    results = results.where("scheduled_from <= ?", start_time)
+    results = results.where("scheduled_to >= ?", quickest_end_time )
   end
 
 end

--- a/app/models/working_hour.rb
+++ b/app/models/working_hour.rb
@@ -2,5 +2,5 @@ class WorkingHour < ApplicationRecord
 belongs_to :user
 belongs_to :funeral
 
-validates :start_time, presence: true
+validates :status, presence: true
 end

--- a/app/views/admin/funerals/new.html.erb
+++ b/app/views/admin/funerals/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: admin_funerals_path, local: true do |f| %>
+<%= form_with(model: [ :admin, @funeral ], local: true) do |f| %>
 <h1>検索結果</h1>
 <span id="start-time-and-hall">
   <%= @funeral.start_time.month %>月
@@ -7,6 +7,10 @@
   <%= @hall_name %>,
   <%= @funeral.number_of_people %>人
 </span>
+<%= f.hidden_field :start_time, value: @funeral.start_time %>
+<%= f.hidden_field :funeral_hall_id, value: @hall_id %>
+<%= f.hidden_field :number_of_people, value: @funeral.number_of_people %>
+
 <h2>スタッフ</h2>
 
   <!-- 該当スタッフ表示 -->
@@ -25,6 +29,7 @@
                     <%= user.name %>
                   </label>
                 </div>
+                <%= working_hour.hidden_field :status, value: 1 %>
               <% end %>
 
               </div>
@@ -38,7 +43,7 @@
     <div class="vertical-menu">
       <% @clients.each do |client| %>
         <label>
-          <%= f.radio_button :client, client.id %>
+          <%= f.radio_button :client_id, client.id %>
           <%= client.name %>
         </label>
       <% end %>

--- a/app/views/admin/funerals/search_page.html.erb
+++ b/app/views/admin/funerals/search_page.html.erb
@@ -10,7 +10,7 @@
         <% @days.each_with_index do |day, i| %>
           <li class='item'>
             <div class='input-container'>
-              <%=f.radio_button :start_time, day, class: 'radio-button' %>
+              <%=f.radio_button :start_date, day, class: 'radio-button' %>
 
               <div class='radio-tile'>
                 <label class='radio-tile-label'>
@@ -35,10 +35,12 @@
 
   <!-- TimeDropper -->
   <h2>開始時間と人数</h2>
-  <input type='text' id='alarm'>
+  <!-- <input type='text' id='alarm'> -->
+  <%= f.text_field :start_time, id: 'alarm' %>
 
   <!-- NumberPicker -->
-  <input type='number' min='1' max='100' value='1' />
+  <!-- <input type='number' min='1' max='100' value='1' /> -->
+  <%= f.number_field :number_of_people, min: '1', max: '100', value: '1' %>
 
   <!-- 会場選択 -->
   <h2>斎場</h2>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module KomoService
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    config.time_zone = 'Tokyo'
     config.generators do |g|
       g.test_framework :rspec,
                        fixtures: true,

--- a/spec/factories/working_hours.rb
+++ b/spec/factories/working_hours.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :working_hour do
-    start_time { "Sun, 25 Dec 2019 00:00:00 +0000" }
+    status { 0 }
     user
     funeral
   end

--- a/spec/models/working_hour_spec.rb
+++ b/spec/models/working_hour_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe WorkingHour, type: :model do
     end
 
     context '通らない' do
-      describe 'start_time' do
+      describe 'status' do
         it '空だとNG' do
-          working_hour.start_time = ''
+          working_hour.status = ''
           expect(working_hour).to be_invalid
         end
       end


### PR DESCRIPTION
## 概要
案件を入力＝＞該当スタッフを検索＝＞保存
のフローを実装しました。

## 詳細
views/admin/funerals/search_page.html.erb
![image](https://user-images.githubusercontent.com/43634511/56879451-be7b5000-6a93-11e9-9036-c1649a3215e5.png)

views/admin/funerals/new.html.erb
![image](https://user-images.githubusercontent.com/43634511/56879437-a4da0880-6a93-11e9-9b29-c50c5ebdb5b9.png)

 ## notice
 `search_page.html.erb` =>  `new.html.erb` と遷移しますが、
 `search`ページのsubmitボタンではDBに登録せず、パラメータだけを送信し、
 `new`ページのsubmitボタンで、 `Funeral`と `WorkingHour`テーブルに同時にデータが保存されます。